### PR TITLE
Update diesel requirement to <1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["database"]
 
 [dependencies]
 byteorder = "1.0"
-diesel = { version = ">=1.2, <1.4", features = ["postgres"] }
+diesel = { version = ">=1.2, <1.5", features = ["postgres"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This just bumps up the restriction on diesel to allow v1.4.*.